### PR TITLE
ignore duplicate crate warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,8 +525,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "git+https://github.com/hyperium/hyper-tls?rev=95ebd8d3ac8785e552fc9fee0ffac141bb361423#95ebd8d3ac8785e552fc9fee0ffac141bb361423"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "docker-dns-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.76.0"
+rust-version = "1.77.0"
 authors = ["Kristof Mattei"]
 description = "Rust end-to-end application"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ hickory-server = "0.24.0"
 http = "1.1.0"
 http-body-util = "0.1.1"
 hyper = { version = "1.2.0", default-features = false }
-hyper-tls = { git = "https://github.com/hyperium/hyper-tls", rev = "95ebd8d3ac8785e552fc9fee0ffac141bb361423", features = [
+hyper-tls = { version = "0.6.0", default-features = false, features = [
     "vendored",
 ] }
 hyper-unix-socket = "0.0.0-development"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76.0@sha256:d36f9d8a9a4c76da74c8d983d0d4cb146dd2d19bb9bd60b704cdcf70ef868d3a as builder
+FROM rust:1.77.0@sha256:00e330d2e2cdada2b75e9517c8359df208b3c880c5e34cb802c120083d50af35 as builder
 
 ARG TARGET=x86_64-unknown-linux-musl
 ARG APPLICATION_NAME

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,16 @@
+allowed-duplicate-crates = [
+    "bitflags",
+    "heck",
+    "idna",
+    "regex-automata",
+    "regex-syntax",
+    "windows-sys",
+    "windows-targets",
+    "windows_aarch64_gnullvm",
+    "windows_aarch64_msvc",
+    "windows_i686_gnu",
+    "windows_i686_msvc",
+    "windows_x86_64_gnu",
+    "windows_x86_64_gnullvm",
+    "windows_x86_64_msvc",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update rust to v1.77.0**
- **chore: ignore warning certain packages pulling in same crate with different version, and moved hyper-tls to crates.io version**
