### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -42,7 +42,7 @@ jobs:
     if: |
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  semgrep:
+  scan:
     name: Scan
     runs-on: ubuntu-latest
 
@@ -22,17 +22,41 @@ jobs:
       image: returntocorp/semgrep:1.66.0@sha256:2fd35fa409f209e0fea0c2d72cf1e5b801a607959a93b13d04822bb3b6a9dfe4
 
     steps:
-      - name: Check out repo
+      - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
       - name: Run semgrep
-        shell: bash
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           semgrep ci --sarif --output=semgrep.sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: semgrep.sarif # name of the artifact
+          path: semgrep.sarif # path of the file to be part of the artifact (think file added to a zip)
+
+  upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    needs:
+      - scan
+
+    steps:
+      # this checkout satisfies github/codeql-action's need for certain variables to link the sarif to the right commit sha
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          show-progress: false
+
+      - name: Download artifact
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: semgrep.sarif # name of the artifact
+          path: . # WHERE to unpack all files part of the artifact
 
       - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
         shell: bash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,14 @@
 {
-    "rust-analyzer.runnables.extraEnv": {
-        "RUST_LOG": "DEBUG,docker_dns_rs=TRACE"
-    },
-    "rust-analyzer.debug.openDebugPane": true,
+    "debug.internalConsoleOptions": "openOnSessionStart",
+    "prettier.configPath": "./.prettierrc.cjs",
     "rust-analyzer.debug.engineSettings": {
         "lldb": {
             "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         }
     },
-    "debug.internalConsoleOptions": "openOnSessionStart"
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,docker_dns_rs=TRACE"
+    }
 }


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.61.1**
- **chore(deps): update dorny/paths-filter action to v3.0.1**
- **chore(deps): update github/codeql-action action to v3.24.2**
- **chore(deps): update github/codeql-action action to v3.24.3**
- **chore(deps): update rust:1.76.0 docker digest to a71cd88**
- **chore: explicitely set prettierrc's path**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.62.0**
- **chore(deps): update rui314/setup-mold digest to 910273f**
- **chore(deps): update github/codeql-action action to v3.24.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/download-artifact action to v4.1.3**
- **chore(deps): update docker/setup-buildx-action action to v3.1.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.63.0**
- **chore: align title**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.1**
- **chore(deps): update npm to >=10.5.0**
- **chore(deps): update github/codeql-action action to v3.24.6**
- **chore(deps): update actions/cache action to v4.0.1**
- **chore(deps): update rui314/setup-mold digest to c9803d2**
- **chore(deps): update actions/download-artifact action to v4.1.4**
- **chore(deps): update dorny/paths-filter action to v3.0.2**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 77b7c17**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.64.0**
- **chore(deps): update docker/build-push-action action to v5.2.0**
- **chore(deps): update rui314/setup-mold digest to 65ebd6e**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.65.0**
- **chore(deps): update rust:1.76.0 docker digest to 969ca54**
- **chore(deps): update actions/checkout action to v4.1.2**
- **chore(deps): update rust:1.76.0 docker digest to 2d1630a**
- **chore(deps): update github/codeql-action action to v3.24.7**
- **chore(deps): update rust:1.76.0 docker digest to af1e799**
- **chore(deps): update rust:1.76.0 docker digest to d36f9d8**
- **chore(deps): update docker/login-action action to v3.1.0**
- **chore(deps): update docker/build-push-action action to v5.3.0**
- **chore(deps): update docker/setup-buildx-action action to v3.2.0**
- **fix(deps): update rust crate color-eyre to 0.6.3**
- **chore(deps): update dependency @semantic-release/github to v10**
- **chore(deps): update dependency semantic-release to v23.0.3**
- **chore(deps): update dependency semantic-release to v23.0.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/commit-analyzer to v12**
- **chore(deps): update dependency semantic-release to v23.0.5**
- **chore(deps): update github/codeql-action action to v3.24.8**
- **chore(deps): update actions/cache action to v4.0.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.66.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.0**
- **fix: don't set shell, not needed in semgrep container**
- **fix: separate scan and fixup, as the scan container doesn't have bash / jq anymore**
- **fix: only upload sarif file itself**
- **fix: set unpack folder, not filepath**
- **chore: checkout to satisfy the codeql tool**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.1**
- **chore(deps): update rust to v1.77.0**
- **chore(deps): update github/codeql-action action to v3.24.9**
