### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,14 @@ jobs:
           plugins: ""
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@1b5b448b98e58ba90d1a1a1d9fcb72ca2263be46 # v1
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: reports/results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Fail if tests failed
         shell: bash
         if: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -955,9 +955,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags",
  "errno",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "It's written in Rust!",
   "main": "src/main.rs",
   "scripts": {
-    "prettier": "prettier --write .",
+    "format": "prettier --write .",
     "release": "semantic-release"
   },
   "engines": {


### PR DESCRIPTION
- **chore(deps): update dependency @semantic-release/github to v10.1.5**
- **chore(deps): update returntocorp/semgrep docker tag to v1.85.0**
- **chore(deps): update dependency @semantic-release/github to v10.1.6**
- **chore(deps): update rui314/setup-mold digest to 0bf4f07**
- **chore(deps): update dependency semantic-release to v24.1.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.26.3**
- **chore(deps): update dependency @semantic-release/github to v10.1.7**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 3614a93**
- **chore(deps): update dependency node to v20.17.0**
- **chore(deps): update github/codeql-action action to v3.26.4**
- **chore(deps): update github/codeql-action action to v3.26.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update npm to >=10.8.3**
- **fix: report tests to codecov for tracking**
- **chore: formatting**
- **chore(deps): pin codecov/test-results-action action to 1b5b448**
