### PR TITLE
update from upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".vscode/rust-prettifier-for-lldb"]
+	path = .vscode/rust-prettifier-for-lldb
+	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git
-.github/actions/
+.mypy_cache
+.vscode/rust-prettifier-for-lldb
 CHANGELOG.md
 profiling
 reports

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,0 +1,1 @@
+./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1138,7 +1138,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",


### PR DESCRIPTION
- **chore(deps): update rust:1.86.0 docker digest to 563b33d**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.28.14**
- **chore(deps): update github/codeql-action action to v3.28.15**
- **chore(deps): update rust:1.86.0 docker digest to 2494472**
- **chore(deps): update rust:1.86.0 docker digest to 6a6dda6**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.0**
- **chore(deps): update npm to >=11.3.0**
- **chore(deps): update rust:1.86.0 docker digest to 9fdf93f**
- **chore(deps): update rust:1.86.0 docker digest to 7b65306**
- **chore(deps): update returntocorp/semgrep docker tag to v1.118.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.1**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.2**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a87c2e8**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/setup-node action to v4.4.0**
- **chore(deps): update codecov/codecov-action action to v5.4.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.119.0**
- **chore(deps): update softprops/action-gh-release action to v2.2.2**
- **chore(deps): lock file maintenance**
- **fix: start tracking lldb debug helper**
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.0**
- **chore(deps): update github/codeql-action action to v3.28.16**
- **chore(deps): update node.js to v22.15.0**
- **chore(deps): update docker/build-push-action action to v6.16.0**
- **chore(deps): update actions/download-artifact action to v4.3.0**
- **chore: set default debug visualizer**
