### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -651,6 +651,10 @@ jobs:
     name: Publish Docker container
     runs-on: ubuntu-latest
     needs:
+      - cargo-build
+      - cargo-clippy-and-report
+      - cargo-fmt
+      - cargo-test-and-report
       - docker-build
     # Check if the event is not triggered by a fork
     if: |
@@ -744,8 +748,8 @@ jobs:
     needs:
       - calculate-version
       - cargo-build
-      - cargo-fmt
       - cargo-clippy-and-report
+      - cargo-fmt
       - cargo-test-and-report
       - docker-build
       - docker-publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ ARG TARGET=aarch64-unknown-linux-musl
 
 FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
 
-COPY ./build-scripts/setup-env.sh .
+COPY ./build-scripts /build-scripts
+
 RUN --mount=type=cache,id=apt-cache,from=rust-base,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,from=rust-base,target=/var/lib/apt,sharing=locked \
-    ./setup-env.sh
+    /build-scripts/setup-env.sh
 
 RUN rustup target add ${TARGET}
 
@@ -37,36 +38,32 @@ RUN rustup target add ${TARGET}
 # This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
 # That means that if our dependencies don't change rebuilding is much faster
 WORKDIR /build
-RUN cargo new ${APPLICATION_NAME}
 
-WORKDIR /build/${APPLICATION_NAME}
+RUN cargo init --name ${APPLICATION_NAME}
 
-COPY ./build-scripts/build.sh .
+COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
 
-COPY .cargo ./.cargo
-COPY Cargo.toml Cargo.lock ./
-
-RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
-    --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    ./build.sh build --release --target ${TARGET}
+RUN --mount=type=cache,target=/build/target,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    /build-scripts/build.sh build --release --target ${TARGET}
 
 # Rust full build
 FROM rust-cargo-build AS rust-build
 
-WORKDIR /build/${APPLICATION_NAME}
+WORKDIR /build
 
 # now we copy in the source which is more prone to changes and build it
-COPY src ./src
+COPY ./src ./src
 
 # ensure cargo picks up on the change
 RUN touch ./src/main.rs
 
 # --release not needed, it is implied with install
-RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
-    --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    ./build.sh install --path . --locked --target ${TARGET} --root /output
+RUN --mount=type=cache,target=/build/target,sharing=locked \
+    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    /build-scripts/build.sh install --path . --locked --target ${TARGET} --root /output
 
 # Container user setup
 FROM --platform=${BUILDPLATFORM} alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS passwd-build
@@ -82,13 +79,12 @@ ARG APPLICATION_NAME
 COPY --from=passwd-build /tmp/group_root /etc/group
 COPY --from=passwd-build /tmp/passwd_root /etc/passwd
 
-# the default user is root, but we're being explicit here
-USER root
-
-WORKDIR /app
-
 COPY --from=rust-build /output/bin/${APPLICATION_NAME} /app/entrypoint
 
+USER root
+
 ENV RUST_BACKTRACE=full
+
+WORKDIR /app
 
 ENTRYPOINT ["/app/entrypoint"]


### PR DESCRIPTION
- **chore(deps): update node.js to v22.17.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.127.0**
- **chore(deps): update dependency prettier to v3.6.1**
- **chore: cleanup**
- **chore: don't push image cargo build/test/... failed**
- **chore: fix dockerfile instruction order**
- **chore(deps): update returntocorp/semgrep docker tag to v1.127.1**
- **chore(deps): update prettier-plugin-sh (npm) to v0.18.0**
- **chore(deps): update rust docker tag to v1.88.0**
- **chore(deps): update rust to v1.88.0**
