### PR TITLE
update from upstream

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -4,6 +4,7 @@ shared: &shared
   - "build-scripts/**"
 docker:
   - *shared
+  - ".dockerignore"
   - Dockerfile
 rust:
   - *shared

--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -96,7 +96,8 @@ else
     api_path="/users/$user"
 fi
 
-registry_base="ghcr.io/$target/$package_name"
+# Docker references must be lowercase
+registry_base="ghcr.io/${target,,}/${package_name,,}"
 
 # Check if gh CLI is installed and authenticated
 if ! command -v gh &> /dev/null; then
@@ -124,15 +125,15 @@ if ! command -v jq &> /dev/null; then
 fi
 
 # Check if skopeo or docker is available for manifest inspection
+# Without manifest inspection every untagged platform-specific image looks orphaned, so refuse to run
 manifest_tool=""
 if command -v skopeo &> /dev/null; then
     manifest_tool="skopeo"
 elif command -v docker &> /dev/null; then
     manifest_tool="docker"
 else
-    echo "Warning: Neither 'skopeo' nor 'docker' found. Cannot inspect multi-platform manifests." >&2
-    echo "         Platform-specific images may be incorrectly deleted." >&2
-    echo "         Install 'skopeo' or 'docker' to fix this." >&2
+    echo "Error: Neither 'skopeo' nor 'docker' found. Cannot inspect multi-platform manifests, refusing to delete anything." >&2
+    exit 1
 fi
 
 # ========== UTILITY FUNCTIONS ==========
@@ -244,36 +245,46 @@ get_first_tag() {
 
 # Fetch manifest and extract referenced digests (for multi-platform images)
 # Returns newline-separated list of sha256 digests (without 'sha256:' prefix)
+# Fails when the manifest cannot be fetched, an empty result only means "not an index"
 get_referenced_digests() {
     local image_ref="$1"
 
-    if [[ -z "$manifest_tool" ]]; then
-        return 0
-    fi
-
     local manifest=""
     if [[ "$manifest_tool" == "skopeo" ]]; then
-        manifest=$(skopeo inspect --raw "docker://${image_ref}" 2> /dev/null) || return 0
+        manifest=$(skopeo inspect --raw "docker://${image_ref}") || return 1
     elif [[ "$manifest_tool" == "docker" ]]; then
-        manifest=$(docker buildx imagetools inspect --raw "$image_ref" 2> /dev/null) || return 0
+        manifest=$(docker buildx imagetools inspect --raw "$image_ref") || return 1
     fi
 
     if [[ -z "$manifest" ]]; then
+        return 1
+    fi
+
+    if echo "$manifest" | jq --exit-status '.manifests' > /dev/null 2>&1; then
+        echo "$manifest" | jq --raw-output '.manifests[].digest // empty' | sed 's/^sha256://'
+    fi
+}
+
+# Protect every digest referenced by the manifest of the version's first tag
+# An uninspectable manifest aborts the run: treating it as "no children" would delete live platform-specific images
+protect_referenced_digests() {
+    local tags_json="$1"
+    local first_tag ref_digest ref_digests
+
+    first_tag=$(get_first_tag "$tags_json")
+    if [[ -z "$first_tag" ]]; then
         return 0
     fi
 
-    # Check if this is a manifest list/index (multi-platform)
-    local media_type
-    media_type=$(echo "$manifest" | jq --raw-output '.mediaType // .schemaVersion // empty')
-
-    # Multi-platform manifest indicators:
-    # - application/vnd.oci.image.index.v1+json
-    # - application/vnd.docker.distribution.manifest.list.v2+json
-    # - Has .manifests array
-    if echo "$manifest" | jq --exit-status '.manifests' > /dev/null 2>&1; then
-        # Extract digests from manifests array
-        echo "$manifest" | jq --raw-output '.manifests[].digest // empty' | sed 's/^sha256://'
+    if ! ref_digests=$(get_referenced_digests "$registry_base:$first_tag"); then
+        echo "Error: Failed to inspect manifest for $registry_base:$first_tag, refusing to delete anything" >&2
+        exit 1
     fi
+
+    while IFS= read -r ref_digest; do
+        [[ -z "$ref_digest" ]] && continue
+        protected_digests["$ref_digest"]="referenced by $first_tag manifest"
+    done <<< "$ref_digests"
 }
 
 # ========== PHASE 1: COLLECT ALL VERSION DATA ==========
@@ -364,15 +375,7 @@ for version_id in "${all_version_ids[@]}"; do
         fi
 
         # Fetch manifest to protect referenced platform-specific images
-        first_tag=$(get_first_tag "$tags")
-        if [[ -n "$first_tag" ]]; then
-            echo "Inspecting manifest for protected image: $registry_base:$first_tag"
-            while IFS= read -r ref_digest; do
-                [[ -z "$ref_digest" ]] && continue
-                protected_digests["$ref_digest"]="referenced by $first_tag manifest"
-                echo "  Protected platform-specific digest: ${ref_digest:0:12}..."
-            done <<< "$(get_referenced_digests "$registry_base:$first_tag")"
-        fi
+        protect_referenced_digests "$tags"
         continue
     fi
 
@@ -410,19 +413,9 @@ for version_id in "${all_version_ids[@]}"; do
         fi
     fi
 
-    # Not a delete candidate, might reference other images
-    # Check if this is a multi-platform manifest we should inspect
-    first_tag=$(get_first_tag "$tags")
-    if [[ -n "$first_tag" ]]; then
-        while IFS= read -r ref_digest; do
-            [[ -z "$ref_digest" ]] && continue
-            # Only protect if not already marked for deletion
-            ref_version_id="${digest_to_version[$ref_digest]:-}"
-            if [[ -z "$ref_version_id" ]] || [[ -z "${delete_candidates[$ref_version_id]:-}" ]]; then
-                protected_digests["$ref_digest"]="referenced by $first_tag manifest"
-            fi
-        done <<< "$(get_referenced_digests "$registry_base:$first_tag")"
-    fi
+    # Not a delete candidate, protect everything its manifest references
+    # Unconditionally: gating on delete_candidates would make protection depend on API return order
+    protect_referenced_digests "$tags"
 done
 
 # ========== PHASE 3: FILTER DELETE CANDIDATES ==========

--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -319,10 +319,10 @@ protect_referenced_digests() {
 echo "Querying container versions for $target, package $package_name..."
 
 # Associative arrays for version data
-declare -A version_tags      # version_id -> tags JSON
-declare -A version_digest    # version_id -> sha256 digest (without prefix)
-declare -A version_created   # version_id -> created_at timestamp
-declare -A digest_to_version # sha256 digest -> version_id
+declare -A version_tags=()      # version_id -> tags JSON
+declare -A version_digest=()    # version_id -> sha256 digest (without prefix)
+declare -A version_created=()   # version_id -> created_at timestamp
+declare -A digest_to_version=() # sha256 digest -> version_id
 
 # Arrays for tracking
 all_version_ids=()
@@ -382,11 +382,11 @@ echo ""
 echo "=== PHASE 2: DETERMINING PROTECTED VERSIONS ==="
 
 # Protected digests: sha256 hashes that must not be deleted
-declare -A protected_digests # sha256 -> reason
+declare -A protected_digests=() # sha256 -> reason
 
 # Track versions by category
-declare -A protected_versions # version_id -> reason
-declare -A delete_candidates  # version_id -> reason
+declare -A protected_versions=() # version_id -> reason
+declare -A delete_candidates=()  # version_id -> reason
 
 for version_id in "${all_version_ids[@]}"; do
     tags="${version_tags[$version_id]}"
@@ -455,7 +455,11 @@ final_delete_versions=()
 final_delete_reasons=()
 
 # Sort delete candidate keys for consistent output
-sorted_candidates=($(printf '%s\n' "${!delete_candidates[@]}" | sort --numeric-sort))
+# printf emits one empty line for an empty array, which mapfile would turn into a bogus entry
+sorted_candidates=()
+if ((${#delete_candidates[@]} > 0)); then
+    mapfile -t sorted_candidates < <(printf '%s\n' "${!delete_candidates[@]}" | sort --numeric-sort)
+fi
 
 for version_id in "${sorted_candidates[@]}"; do
     digest="${version_digest[$version_id]:-}"

--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -7,7 +7,7 @@ org=""
 user=""
 package_name="package"
 per_page=100
-max_api_attempts=3
+max_attempts=3
 dry_run=false
 skip_confirmation=false
 cleanup_pr_images=true
@@ -142,14 +142,14 @@ fi
 # Only emits stdout of the last attempt, so partial output of failed attempts is discarded
 gh_api() {
     local attempt output
-    for ((attempt = 1; attempt <= max_api_attempts; attempt++)); do
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
         if output=$(gh api "$@"); then
             printf '%s' "$output"
             return 0
         fi
 
-        if [[ "$attempt" -lt "$max_api_attempts" ]]; then
-            echo "Warning: gh api call failed (attempt $attempt of $max_api_attempts), retrying in $((attempt * 2))s..." >&2
+        if [[ "$attempt" -lt "$max_attempts" ]]; then
+            echo "Warning: gh api call failed (attempt $attempt of $max_attempts), retrying in $((attempt * 2))s..." >&2
             sleep $((attempt * 2))
         fi
     done
@@ -249,7 +249,7 @@ fetch_manifest() {
     local image_ref="$1"
     local attempt output rc
 
-    for ((attempt = 1; attempt <= max_api_attempts; attempt++)); do
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
         rc=0
         if [[ "$manifest_tool" == "skopeo" ]]; then
             output=$(skopeo inspect --raw --command-timeout 70s --retry-times 5 "docker://${image_ref}") || rc=$?
@@ -262,8 +262,8 @@ fetch_manifest() {
             return 0
         fi
 
-        if [[ "$attempt" -lt "$max_api_attempts" ]]; then
-            echo "Warning: manifest inspection of $image_ref failed (attempt $attempt of $max_api_attempts), retrying in $((attempt * 2))s..." >&2
+        if [[ "$attempt" -lt "$max_attempts" ]]; then
+            echo "Warning: manifest inspection of $image_ref failed (attempt $attempt of $max_attempts), retrying in $((attempt * 2))s..." >&2
             sleep $((attempt * 2))
         fi
     done

--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -243,6 +243,34 @@ get_first_tag() {
     echo "$tags_json" | jq --raw-output '.[0] // empty'
 }
 
+# Fetch the raw manifest, retrying transient registry failures with backoff
+# skopeo's --retry-times does not retry a bare 500, so retry at the shell level too
+fetch_manifest() {
+    local image_ref="$1"
+    local attempt output rc
+
+    for ((attempt = 1; attempt <= max_api_attempts; attempt++)); do
+        rc=0
+        if [[ "$manifest_tool" == "skopeo" ]]; then
+            output=$(skopeo inspect --raw --command-timeout 70s --retry-times 5 "docker://${image_ref}") || rc=$?
+        else
+            output=$(docker buildx imagetools inspect --raw "$image_ref") || rc=$?
+        fi
+
+        if [[ "$rc" -eq 0 ]]; then
+            printf '%s' "$output"
+            return 0
+        fi
+
+        if [[ "$attempt" -lt "$max_api_attempts" ]]; then
+            echo "Warning: manifest inspection of $image_ref failed (attempt $attempt of $max_api_attempts), retrying in $((attempt * 2))s..." >&2
+            sleep $((attempt * 2))
+        fi
+    done
+
+    return 1
+}
+
 # Fetch manifest and extract referenced digests (for multi-platform images)
 # Returns newline-separated list of sha256 digests (without 'sha256:' prefix)
 # Fails when the manifest cannot be fetched, an empty result only means "not an index"
@@ -250,11 +278,7 @@ get_referenced_digests() {
     local image_ref="$1"
 
     local manifest=""
-    if [[ "$manifest_tool" == "skopeo" ]]; then
-        manifest=$(skopeo inspect --raw "docker://${image_ref}") || return 1
-    elif [[ "$manifest_tool" == "docker" ]]; then
-        manifest=$(docker buildx imagetools inspect --raw "$image_ref") || return 1
-    fi
+    manifest=$(fetch_manifest "$image_ref") || return 1
 
     if [[ -z "$manifest" ]]; then
         return 1
@@ -276,6 +300,8 @@ protect_referenced_digests() {
         return 0
     fi
 
+    echo "Inspecting manifest for protected image: $registry_base:$first_tag"
+
     if ! ref_digests=$(get_referenced_digests "$registry_base:$first_tag"); then
         echo "Error: Failed to inspect manifest for $registry_base:$first_tag, refusing to delete anything" >&2
         exit 1
@@ -283,6 +309,7 @@ protect_referenced_digests() {
 
     while IFS= read -r ref_digest; do
         [[ -z "$ref_digest" ]] && continue
+        echo "  Protected platform-specific digest: ${ref_digest:0:12}..."
         protected_digests["$ref_digest"]="referenced by $first_tag manifest"
     done <<< "$ref_digests"
 }

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -157,6 +157,8 @@ rulesets:
               integration_id: 15368
             - context: Spellcheck
               integration_id: 15368
+            - context: Zizmor
+              integration_id: 15368
       - type: pull_request
         parameters:
           required_approving_review_count: 0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Run actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -29,3 +29,14 @@ jobs:
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
           pyflakes: false
+
+      # actionlint only reaches shell inside `run:` blocks, standalone scripts need their own pass
+      - name: Install shellcheck
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
+        with:
+          tool: shellcheck
+
+      - name: Run shellcheck
+        shell: bash
+        run: |
+          git ls-files -z '*.sh' | xargs --null shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,12 @@ jobs:
         id: version
         run: |
           latest_tag=$(git describe --tags --abbrev=0 || true)
-          bumped=$(git-cliff --offline --bumped-version --unreleased)
+          bumped=$(git-cliff --bumped-version --unreleased --offline)
 
           # If git-cliff didn't bump (e.g. chore/ci only commits), force a patch increment
           # so we never tag a Docker image with the same version as the last release.
           if [ "${bumped}" = "${latest_tag}" ]; then
-            bumped=$(git-cliff --offline --bumped-version --bump patch --unreleased)
+            bumped=$(git-cliff --bumped-version --bump patch --unreleased --offline)
             echo "Force bumping to ${bumped}"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-cliff to generate changelog & next version number
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: git-cliff
 
@@ -165,7 +165,7 @@ jobs:
       - *checkout
 
       - name: Install cargo-edit to do set-version
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-edit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Check if we actually made changes
@@ -119,6 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     name: Build Rust code
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     uses: ./.github/workflows/rust.yml
-    secrets: inherit
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,8 @@ jobs:
             echo "Force bumping to ${bumped}"
           fi
 
-          # remove v
-          version="${bumped//v/}"
-
-          # store
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # tags are vX.Y.Z, cargo versions are not prefixed
+          echo "version=${bumped#v}" >> "${GITHUB_OUTPUT}"
 
   docker-prepare-variables:
     name: Prepare Docker variables and version bump patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     uses: ./.github/workflows/rust.yml
     permissions:
-      checks: write
+      checks: write # publish-unit-test-result-action creates a check run
       contents: read
-      id-token: write
-      issues: read
-      pull-requests: write
+      id-token: write # codecov-action authenticates over OIDC
+      issues: read # publish-unit-test-result-action needs this in private repos
+      pull-requests: write # publish-unit-test-result-action comments the test summary
 
   repo-has-container:
     name: Repo has container?
@@ -80,7 +80,7 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: read # dorny/paths-filter reads the PR's changed files
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
       rust: ${{ steps.filter.outputs.rust }}
@@ -194,6 +194,9 @@ jobs:
       - name: Variables
         shell: bash
         id: variables
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # The application name, used in the Dockerfile
           # split at the last / and keep that (kristof-mattei/repo-name -> repo-name)
@@ -210,7 +213,7 @@ jobs:
               "EOF" >> "$GITHUB_OUTPUT"
 
           # This is the unique docker tag
-          unique_tag=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
+          unique_tag="pr-${BASE_SHA}-${HEAD_SHA}"
           echo "unique_tag=${unique_tag}" >> "${GITHUB_OUTPUT}"
 
           # The registry to which we'll push
@@ -240,7 +243,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
-      packages: write
+      packages: write # push the build cache to ghcr.io
     needs:
       - calculate-version
       - architectures
@@ -269,6 +272,7 @@ jobs:
         env:
           CACHE_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}
           PLATFORM: ${{ matrix.platform }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
           # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
@@ -279,7 +283,7 @@ jobs:
           echo "unique_tag_arch=${UNIQUE_TAG}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
           runner_arch="${RUNNER_ARCH,,}"
-          echo "buildcache_pr_ref=${CACHE_IMAGE_NAME}:buildcache-pr-${{ github.event.pull_request.number }}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
+          echo "buildcache_pr_ref=${CACHE_IMAGE_NAME}:buildcache-pr-${PR_NUMBER}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
           echo "buildcache_main_ref=${CACHE_IMAGE_NAME}:buildcache-main-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker
@@ -380,7 +384,7 @@ jobs:
     outputs:
       digest: ${{ steps.local_image.outputs.digest }}
     permissions:
-      packages: write
+      packages: write # push the PR's image to ghcr.io
     needs:
       - calculate-version
       - docker-prepare-variables
@@ -541,12 +545,12 @@ jobs:
     name: Attest Docker container
     runs-on: ubuntu-26.04
     permissions:
-      artifact-metadata: write
-      attestations: write
+      artifact-metadata: write # actions/attest
+      attestations: write # actions/attest
       contents: read
-      id-token: write
-      packages: write
-      pull-requests: write
+      id-token: write # actions/attest
+      packages: write # actions/attest pushes the attestation to ghcr.io
+      pull-requests: write # docker/scout-action posts the comparison as a PR comment
     needs:
       - docker-prepare-variables
       - docker-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   changes:
     name: Detect changes
@@ -173,8 +174,10 @@ jobs:
 
       - name: Update Cargo.toml's version
         shell: bash
+        env:
+          VERSION: ${{ needs.calculate-version.outputs.version }}
         run: |
-          cargo set-version ${{ needs.calculate-version.outputs.version }}
+          cargo set-version "${VERSION}"
 
           git diff
 
@@ -196,11 +199,10 @@ jobs:
         id: variables
         run: |
           # The application name, used in the Dockerfile
-          application_name=${{ env.IMAGE_NAME }}
           # split at the last / and keep that (kristof-mattei/repo-name -> repo-name)
-          application_name=${application_name##*/}
+          application_name="${IMAGE_NAME##*/}"
           # lowercase
-          application_name=${application_name,,}
+          application_name="${application_name,,}"
           echo "application_name=${application_name}" >> "${GITHUB_OUTPUT}"
 
           # The application's description, from Cargo.toml
@@ -215,13 +217,11 @@ jobs:
           echo "unique_tag=${unique_tag}" >> "${GITHUB_OUTPUT}"
 
           # The registry to which we'll push
-          registry=${{ env.REGISTRY }}
-          registry=${registry,,}
+          registry="${REGISTRY,,}"
           echo "registry=${registry}" >> "${GITHUB_OUTPUT}"
 
           # The final full image name, which is the registry, the owner and the repo name
-          image_name=${{ env.IMAGE_NAME }}
-          image_name=${image_name,,}
+          image_name="${IMAGE_NAME,,}"
           echo "full_image_name_remote_registry=${registry}/${image_name}" >> "${GITHUB_OUTPUT}"
 
           # The cache registry, separate from the main image registry
@@ -270,20 +270,20 @@ jobs:
         shell: bash
         id: variables
         env:
+          CACHE_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}
           PLATFORM: ${{ matrix.platform }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
           # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
           platform_no_slashes="${PLATFORM//\//-}"
           echo "platform_no_slashes=${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
           # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
-          unique_tag_arch=${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform_no_slashes}
-          echo "unique_tag_arch=${unique_tag_arch}" >> "${GITHUB_OUTPUT}"
+          echo "unique_tag_arch=${UNIQUE_TAG}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
-          runner_arch="${{ runner.arch }}"
-          runner_arch="${runner_arch,,}"
-          echo "buildcache_pr_ref=${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}:buildcache-pr-${{ github.event.pull_request.number }}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
-          echo "buildcache_main_ref=${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}:buildcache-main-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
+          runner_arch="${RUNNER_ARCH,,}"
+          echo "buildcache_pr_ref=${CACHE_IMAGE_NAME}:buildcache-pr-${{ github.event.pull_request.number }}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
+          echo "buildcache_main_ref=${CACHE_IMAGE_NAME}:buildcache-main-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker
         uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
@@ -439,19 +439,23 @@ jobs:
       - name: Load individual platform images from artifacts & push to registry
         shell: bash
         working-directory: ${{ steps.artifact.outputs.download-path }}
+        env:
+          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
           platforms=()
           while IFS= read -r platform; do
             echo "Loading ${platform//\//-}:"
-            docker load --input "./${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform//\//-}.tar"
+            docker load --input "./${UNIQUE_TAG}-${platform//\//-}.tar"
 
-            full_name_with_platform=${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform//\//-}
+            full_name_with_platform="${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}-${platform//\//-}"
 
             echo "Pushing ${platform//\//-}:"
             docker push "$full_name_with_platform"
 
             platforms+=("$full_name_with_platform")
-          done <<< "${{ env.IMAGE_VARIANTS }}"
+          done <<< "${IMAGE_VARIANTS}"
 
           new_annotations=()
           while IFS= read -r annotation; do
@@ -460,28 +464,35 @@ jobs:
             annotation="${annotation/manifest:/index:}"
             new_annotations+=(--annotation)
             new_annotations+=("${annotation}")
-          done <<< "${{ steps.meta.outputs.annotations }}"
+          done <<< "${ANNOTATIONS}"
 
           # merge the platform containers in a new multiplatform one
           # with the new annotations, and push it to our local registry
-          docker buildx imagetools create "${new_annotations[@]}" --tag "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}" \
+          docker buildx imagetools create "${new_annotations[@]}" --tag "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}" \
             "${platforms[@]}"
 
-          echo "Inspecting ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}:"
-          docker buildx imagetools inspect --raw "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}"
+          echo "Inspecting ${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}:"
+          docker buildx imagetools inspect --raw "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}"
 
       - name: Get digest of image in our local registry
         shell: bash
         id: local_image
+        env:
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
-          digest=$(docker buildx imagetools inspect "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}" --format "{{json .}}" | jq --raw-output ".manifest.digest")
+          digest=$(docker buildx imagetools inspect "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}" --format "{{json .}}" | jq --raw-output ".manifest.digest")
 
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Push from local registry to remote with new tags
         shell: bash
+        env:
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
-          source="docker://${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}"
+          source="docker://${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}"
 
           # skopeo's --retry-times does not retry a bare 500, so retry at the shell level too
           copy_with_retries() {
@@ -511,12 +522,14 @@ jobs:
           # try to upload all of them, if one of them fails, upload the other ones and fail
           while IFS= read -r tag; do
             copy_with_retries "${tag}" || exit_code=1
-          done <<< "${{ steps.meta.outputs.tags }}"
+          done <<< "${NEW_TAGS}"
 
           exit "${exit_code}"
 
       - name: Inspect new remote tags
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           while IFS= read -r new_tag; do
             echo "Inspecting ${new_tag}:"
@@ -525,7 +538,7 @@ jobs:
 
             # empty to get newline
             echo ""
-          done <<< "${{ steps.meta.outputs.tags }}"
+          done <<< "${NEW_TAGS}"
 
   docker-attest:
     name: Attest Docker container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,10 +269,11 @@ jobs:
       - name: Set variables
         shell: bash
         id: variables
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
-          platform_no_slashes=${{ matrix.platform }}
-          platform_no_slashes=${platform_no_slashes//\//-}
+          platform_no_slashes="${PLATFORM//\//-}"
           echo "platform_no_slashes=${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
           # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
@@ -307,10 +308,10 @@ jobs:
       - name: Should we set up QEMU?
         shell: bash
         id: setup_qemu
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          base_platform="${{ matrix.platform }}"
-
-          if ! dpkg-architecture --equal "${base_platform%/*}"; then
+          if ! dpkg-architecture --equal "${PLATFORM%/*}"; then
             echo "setup_qemu=true" >> "${GITHUB_OUTPUT}"
           else
             echo "setup_qemu=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,10 @@ on:
     - cron: "32 23 * * 5"
 
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  # push, pull_request and schedule all run this workflow; on push and schedule
+  # `ref_name` is `main`, so without `event_name` in the group a push to main
+  # cancels an in-flight weekly scan, which is then lost until the next cron
+  group: "${{ github.workflow }} @ ${{ github.event_name }} @ ${{ github.ref_name }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "32 23 * * 5"
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -19,10 +23,9 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-26.04' }}
     permissions:
-      actions: read
+      actions: read # codeql-action reads the workflow run's metadata
       contents: read
-      # required for all workflows
-      security-events: write
+      security-events: write # upload the CodeQL results
 
     strategy:
       fail-fast: false

--- a/.github/workflows/compare-release-image.yml
+++ b/.github/workflows/compare-release-image.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/compare-release-image.yml
+++ b/.github/workflows/compare-release-image.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   compare:
     name: Compare release image against latest

--- a/.github/workflows/compare-release-image.yml
+++ b/.github/workflows/compare-release-image.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  pull-requests: write
 
 env:
   REGISTRY: ghcr.io
@@ -33,6 +31,10 @@ jobs:
   compare:
     name: Compare release image against latest
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: read # pull the images being compared from ghcr.io
+      pull-requests: write # docker/scout-action posts the comparison as a PR comment
     needs:
       - repo-has-container
     if: fromJSON(needs.repo-has-container.outputs.has_container) == true

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 20 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: false # deletes package versions, let it finish
+
 permissions:
   contents: read
 

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           show-progress: false
 
+      # The package is private, manifest inspection (skopeo/docker) needs registry credentials
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run container cleanup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  packages: write
   contents: read
 
 jobs:
@@ -27,6 +26,9 @@ jobs:
   cleanup-containers:
     name: Cleanup containers
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: write # delete container versions
     needs:
       - repo-has-container
     if: |
@@ -57,6 +59,9 @@ jobs:
   cleanup-container-build-cache:
     name: Cleanup container build cache
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: write # delete build cache versions
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   cleanup-containers:
     name: Cleanup containers

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -52,8 +52,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/scripts/cleanup-containers.sh \
-            --user ${{ github.repository_owner }} \
-            --package ${{ github.event.repository.name }} \
+            --user "${GITHUB_REPOSITORY_OWNER}" \
+            --package "${GITHUB_REPOSITORY##*/}" \
             --yes
 
   cleanup-container-build-cache:
@@ -77,6 +77,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/scripts/cleanup-container-build-cache.sh \
-            --user ${{ github.repository_owner }} \
-            --package ${{ github.event.repository.name }}-cache \
+            --user "${GITHUB_REPOSITORY_OWNER}" \
+            --package "${GITHUB_REPOSITORY##*/}-cache" \
             --yes

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       # The package is private, manifest inspection (skopeo/docker) needs registry credentials
@@ -70,6 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Run container build cache cleanup

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Install pnpm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -41,12 +41,13 @@ jobs:
             echo "prerelease=true" >> "${GITHUB_OUTPUT}"
           fi
 
+      # zizmor: ignore[artipacked] the tag steps below read from the remote, which needs the credential in .git/config
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true
           show-progress: false
-          token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 
       - name: Create tag
         shell: bash

--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -8,9 +8,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: false # this job creates tags and releases, let it finish
+
 permissions:
-  contents: write # to create tags
-  pull-requests: write # to close stale release PRs
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +22,9 @@ jobs:
   graduate:
     name: Graduate Release
     runs-on: ubuntu-26.04
+    permissions:
+      contents: write # to create tags
+      pull-requests: write # to close stale release PRs
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
@@ -91,8 +97,11 @@ jobs:
       - name: Generate release notes
         if: steps.check_release.outputs.exists == 'false'
         shell: bash
+        env:
+          # git-cliff reads GITHUB_TOKEN from the environment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git-cliff --output release-notes.md --current --github-token ${{ secrets.GITHUB_TOKEN }}
+          git-cliff --output release-notes.md --current
 
       - name: Create GitHub release
         if: steps.check_release.outputs.exists == 'false'

--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install git-cliff to generate changelog
         if: steps.check_release.outputs.exists == 'false'
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: git-cliff
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 0
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Install git-cliff to lint commits
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: git-cliff
 

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -36,7 +36,7 @@ jobs:
           cargo --version
 
       - name: Install cargo-machete to ensure we don't have unneeded packages
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-machete
 

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Set up toolchain

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -81,7 +81,7 @@ jobs:
           cargo --version
 
       - name: Install cargo-edit to do set-version
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-edit
 

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -51,7 +51,7 @@ jobs:
       url: https://crates.io/crates/${{ github.event.repository.name }}/${{ needs.repo-has-crate.outputs.version }}
     permissions:
       contents: read
-      id-token: write
+      id-token: write # crates-io-auth-action trades this for a publish token
     needs:
       - repo-has-crate
     if: |

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -36,12 +36,11 @@ jobs:
       - name: Determine version
         id: version
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          version="${{ github.ref_name }}"
-          # remove v
-          version="${version//v/}"
-
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # tags are vX.Y.Z, crates.io versions are not prefixed
+          echo "version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
 
   publish-crate:
     name: Publish crate

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Repo has crate?
         id: determine
         shell: bash
+        env:
+          HAS_CRATE: ${{ vars.HAS_CRATE }}
         run: |
-          has_crate="${{ vars.HAS_CRATE }}"
-          echo "has_crate=${has_crate:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_crate=${HAS_CRATE:-false}" >> "${GITHUB_OUTPUT}"
 
       - name: Determine version
         id: version
@@ -86,8 +87,10 @@ jobs:
 
       - name: Set version in Cargo.toml / Cargo.lock
         shell: bash
+        env:
+          VERSION: ${{ needs.repo-has-crate.outputs.version }}
         run: |
-          cargo set-version "${{ needs.repo-has-crate.outputs.version }}"
+          cargo set-version "${VERSION}"
 
           git diff
 

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Set up mold

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,13 +104,13 @@ jobs:
           fi
 
           bump_flag="auto"
-          bumped=$(git-cliff --offline --bumped-version --bump ${bump_flag} --unreleased)
+          bumped=$(git-cliff --bumped-version --bump ${bump_flag} --unreleased --offline)
 
           # If git-cliff didn't bump (e.g. chore/ci only commits), force a patch increment
           # so we never release the same version as the last tag.
           if [ "${bumped}" = "${latest_tag}" ]; then
             bump_flag="patch"
-            bumped=$(git-cliff --offline --bumped-version --bump patch --unreleased)
+            bumped=$(git-cliff --bumped-version --bump patch --unreleased --offline)
             echo "::notice::No conventional bump detected, forcing patch bump"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ concurrency:
   cancel-in-progress: false # this job force-pushes branches and opens PRs, let it finish
 
 permissions:
-  contents: write # to create the release commit via createCommitOnBranch
-  pull-requests: read # to list open release PRs
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,6 +32,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-26.04
+    permissions:
+      contents: write # to create the release commit via createCommitOnBranch
+      pull-requests: read # to list open release PRs
     steps:
       - name: Only on main
         if: |
@@ -65,10 +67,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # git-cliff reads GITHUB_TOKEN from the environment
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
           latest_tag=$(git describe --tags --abbrev=0 || true)
 
-          prerelease="${{ inputs.prerelease }}"
+          prerelease="${PRERELEASE}"
 
           echo "::notice::Latest tag: ${latest_tag:-none}"
           echo "::notice::Pre-release type: ${prerelease}"
@@ -225,6 +228,7 @@ jobs:
       - name: Open or update pull request
         shell: bash
         env:
+          AUTO_MERGE: ${{ inputs.auto_merge }}
           BRANCH: ${{ steps.release.outputs.branch }}
           GH_TOKEN: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
@@ -257,7 +261,7 @@ jobs:
               --body-file diff-CHANGELOG.md
           fi
 
-          if [ "${{ inputs.auto_merge }}" = "true" ]; then
+          if [ "${AUTO_MERGE}" = "true" ]; then
             gh pr merge "${BRANCH}" --auto --merge
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 
       - name: Install git-cliff to generate changelog & next version number
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: git-cliff
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,11 +225,10 @@ jobs:
       - name: Open or update pull request
         shell: bash
         env:
+          BRANCH: ${{ steps.release.outputs.branch }}
           GH_TOKEN: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
-          branch="${{ steps.release.outputs.branch }}"
-          release_version="${{ steps.release.outputs.release_version }}"
-
           # Truncate diff-CHANGELOG.md if it exceeds GitHub's PR character body limit
           max_length=65536
           truncation_message=$'\n\n---\n\n> **Note:** Changelog was truncated because it exceeded GitHub'"'"'s 65,536 character limit.'
@@ -243,7 +242,7 @@ jobs:
           fi
 
           # Check if a PR already exists for this branch
-          existing_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
+          existing_pr=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
 
           if [ -n "$existing_pr" ]; then
             # gh pr edit needs read:org, even for --body (cli/cli#13575).
@@ -253,29 +252,28 @@ jobs:
           else
             gh pr create \
               --base main \
-              --head "${branch}" \
-              --title "chore(release): Release ${release_version}" \
+              --head "${BRANCH}" \
+              --title "chore(release): Release ${RELEASE_VERSION}" \
               --body-file diff-CHANGELOG.md
           fi
 
           if [ "${{ inputs.auto_merge }}" = "true" ]; then
-            gh pr merge "${branch}" --auto --merge
+            gh pr merge "${BRANCH}" --auto --merge
           fi
 
       - name: Clean up stranded branches
         if: ${{ (failure() || cancelled()) && steps.release.outputs.branch != '' }}
         shell: bash
         env:
+          BRANCH: ${{ steps.release.outputs.branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          branch="${{ steps.release.outputs.branch }}"
-
-          git push origin --delete "${branch}-staging" || true
+          git push origin --delete "${BRANCH}-staging" || true
 
           # Deleting the release branch would close its PR, so keep it when one exists.
           # A failing `gh pr list` fails the step (set -e) instead of counting as "no PR".
-          open_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
+          open_pr=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
 
           if [ -z "${open_pr}" ]; then
-            git push origin --delete "${branch}" || true
+            git push origin --delete "${BRANCH}" || true
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,12 @@ jobs:
           echo "Only to be executed on main"
           exit 1
 
+      # zizmor: ignore[artipacked] the release branch is pushed with this credential, see the release step
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true
           show-progress: false
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -128,7 +128,7 @@ jobs:
 
               echo "Looking up the PR for ${parent2} (attempt ${attempt} of 5)"
 
-              if pr_number=$(gh api "/repos/${{ github.repository }}/commits/${parent2}/pulls" --jq '.[0].number'); then
+              if pr_number=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${parent2}/pulls" --jq '.[0].number'); then
                 pr_found=true
                 break
               fi

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -24,8 +24,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  pull-requests: read
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -76,6 +74,10 @@ jobs:
           - "ubuntu-24.04-arm"
         platform: ${{ fromJSON(needs.architectures.outputs.architectures) }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      packages: write # retag build cache images in ghcr.io
+      pull-requests: read # resolve the PR that produced the incoming merge commit
     needs:
       - architectures
       - repo-has-container

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 2
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   architectures:
     name: Build matrix
@@ -106,13 +107,10 @@ jobs:
         run: |
           platform_no_slashes="${PLATFORM//\//-}"
 
-          image_name="${{ env.IMAGE_NAME }}"
-          image_name="${image_name,,}"
-          registry="${{ env.REGISTRY }}"
-          registry="${registry,,}"
+          image_name="${IMAGE_NAME,,}"
+          registry="${REGISTRY,,}"
 
-          runner_arch="${{ runner.arch }}"
-          runner_arch="${runner_arch,,}"
+          runner_arch="${RUNNER_ARCH,,}"
 
           target_ref="${registry}/${image_name}-cache:buildcache-main-${runner_arch}-${platform_no_slashes}"
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -102,9 +102,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          platform_no_slashes="${{ matrix.platform }}"
-          platform_no_slashes="${platform_no_slashes//\//-}"
+          platform_no_slashes="${PLATFORM//\//-}"
 
           image_name="${{ env.IMAGE_NAME }}"
           image_name="${image_name,,}"

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -73,9 +73,11 @@ jobs:
 
       - name: Resolve base and PR head SHAs
         shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           # push event, HEAD^2 is the tip of the incoming PR branch
-          echo "BASE_SHA=${{ github.event.before }}" >> "${GITHUB_ENV}"
+          echo "BASE_SHA=${BEFORE_SHA}" >> "${GITHUB_ENV}"
 
           exit_code=0
           # a commit always has a parent, but if it has 2, the commit is a merge
@@ -131,10 +133,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TAG: "pr-${{ env.BASE_SHA }}-${{ env.INCOMING_PR_HEAD_COMMIT }}"
         run: |
-          repo="${{ github.repository }}"
-          repo_lower="${repo,,}"
+          repo_lower="${GITHUB_REPOSITORY,,}"
 
-          all_tags=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
+          all_tags=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${repo_lower##*/}/versions" \
             --paginate \
             --jq '.[] | .metadata.container.tags[]')
 

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   retag-containers:
     name: Retag the containers
@@ -138,13 +139,13 @@ jobs:
             --jq '.[] | .metadata.container.tags[]')
 
           # search for the PR tag, there can only be zero or one match
-          pr_tag_found=$(echo "${all_tags}" | grep -c "^${{ env.PR_TAG }}\$") || true
+          pr_tag_found=$(echo "${all_tags}" | grep -c "^${PR_TAG}\$") || true
 
           if [ "${pr_tag_found}" -eq 1 ]
           then
             echo "Incoming PR produced a Docker image"
 
-            echo "OLD_TAG=${{ env.PR_TAG }}" >> "${GITHUB_ENV}"
+            echo "OLD_TAG=${PR_TAG}" >> "${GITHUB_ENV}"
             echo "SUFFIX=actual" >> "${GITHUB_ENV}"
           else
             # If we don't have an old tag, then the incoming PR didn't produce a container.
@@ -155,11 +156,11 @@ jobs:
             # so we find the last commit that github processed before this one
             # which will have gone through the same retagging process
             # and use that sha as our key to find the Docker container related to that commit
-            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") || true # .* is actual or retag
+            old_tag=$(echo "${all_tags}" | grep "^sha-${BASE_SHA}-.*\$") || true # .* is actual or retag
 
             if [ -z "${old_tag}" ]
             then
-              echo "::error::No matching source tag found for base SHA ${{ env.BASE_SHA }}"
+              echo "::error::No matching source tag found for base SHA ${BASE_SHA}"
               exit 1
             fi
 
@@ -198,8 +199,10 @@ jobs:
 
       - name: Actually re-tag the container
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               docker buildx imagetools create --tag "${new_tag}" "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done
@@ -214,8 +217,10 @@ jobs:
       - name: Copy the container to Docker Hub
         if: env.DOCKERHUB_IMAGE_NAME != ''
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta-dockerhub.outputs.tags }}
         run: |
-          echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               skopeo copy --all --preserve-digests --command-timeout 70s --retry-times 5 "docker://${FULL_IMAGE_NAME}:${OLD_TAG}" "docker://${new_tag}"
           done

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -22,11 +22,7 @@ concurrency:
   cancel-in-progress: false # no we need them
 
 permissions:
-  artifact-metadata: write
-  attestations: write
   contents: read
-  id-token: write
-  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -56,6 +52,12 @@ jobs:
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-26.04
+    permissions:
+      artifact-metadata: write # actions/attest
+      attestations: write # actions/attest
+      contents: read
+      id-token: write # actions/attest
+      packages: write # retag images in ghcr.io
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 2
 

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -91,8 +91,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          repo="${{ github.repository }}"
-          repo_lower="${repo,,}"
+          repo_lower="${GITHUB_REPOSITORY,,}"
 
           # the source tag is pushed by the push-triggered retag workflow, which may still be running, so poll
           OLD_TAG=""
@@ -102,12 +101,12 @@ jobs:
               sleep 30
             fi
 
-            echo "Looking for source tag sha-${{ github.sha }}-* (attempt ${attempt} of 30)"
+            echo "Looking for source tag sha-${GITHUB_SHA}-* (attempt ${attempt} of 30)"
 
             # || true: no match yet, or a transient api error, both mean retry
-            OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
+            OLD_TAG=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${repo_lower##*/}/versions" \
               --paginate \
-              --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) || true # .* is actual or retag
+              --jq '.[] | .metadata.container.tags[]' | grep "^sha-${GITHUB_SHA}-.*\$" | head --lines 1) || true # .* is actual or retag
 
             if [ -n "${OLD_TAG}" ]; then
               break
@@ -115,7 +114,7 @@ jobs:
           done
 
           if [ -z "${OLD_TAG}" ]; then
-            echo "::error::No matching source tag found for SHA ${{ github.sha }}"
+            echo "::error::No matching source tag found for SHA ${GITHUB_SHA}"
             exit 1
           fi
 

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -33,9 +33,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   retag-containers:
     name: Retag the containers
@@ -148,8 +149,10 @@ jobs:
 
       - name: Actually re-tag the container
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               docker buildx imagetools create --tag "${new_tag}" "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done
@@ -164,10 +167,13 @@ jobs:
       - name: Copy the container to Docker Hub
         if: env.DOCKERHUB_IMAGE_NAME != ''
         shell: bash
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          NEW_TAGS: ${{ steps.meta-dockerhub.outputs.tags }}
         run: |
-          echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
-              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${{ steps.digest.outputs.digest }}" ]; then
+              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${DIGEST}" ]; then
                 echo "${new_tag} already exists, skipping"
                 continue
               fi

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -12,11 +12,7 @@ concurrency:
   cancel-in-progress: false # last one must win in case of multiple releases
 
 permissions:
-  artifact-metadata: write
-  attestations: write
   contents: read
-  id-token: write
-  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,6 +40,12 @@ jobs:
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-26.04
+    permissions:
+      artifact-metadata: write # actions/attest
+      attestations: write # actions/attest
+      contents: read
+      id-token: write # actions/attest
+      packages: write # retag images in ghcr.io
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,12 +76,7 @@ jobs:
 
   cargo-build-windows:
     name: Cargo build Windows
-    runs-on: windows-latest
-    needs:
-      - changes
-    if: |
-      github.event_name == 'pull_request' &&
-      fromJSON(needs.changes.outputs.rust) == true
+    runs-on: windows-2025
     steps:
       - &disable_autocrlf
         name: Disable autocrlf
@@ -112,7 +107,9 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          cargo build ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
+          # -split so a multi-flag CARGO_FEATURES arrives as separate arguments, -ne '' so an empty one adds none
+          $features = ($env:CARGO_FEATURES -split '\s+') -ne ''
+          cargo build @features --all-targets --locked --workspace
 
   cargo-fmt:
     name: Cargo fmt
@@ -266,13 +263,13 @@ jobs:
 
   cargo-test-and-report-windows:
     name: Cargo test (and report) Windows
-    runs-on: windows-latest
+    runs-on: windows-2025
     permissions:
-      checks: write
+      checks: write # publish-unit-test-result-action creates a check run
       contents: read
-      id-token: write
-      issues: read
-      pull-requests: write
+      id-token: write # codecov-action authenticates over OIDC
+      issues: read # publish-unit-test-result-action needs this in private repos
+      pull-requests: write # publish-unit-test-result-action comments the test summary
     steps:
       - *disable_autocrlf
 
@@ -302,7 +299,9 @@ jobs:
           # build-* ones are not parsed by grcov
           LLVM_PROFILE_FILE: "profiling/build-%p-%m.profraw"
         run: |
-          cargo build ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
+          # -split so a multi-flag CARGO_FEATURES arrives as separate arguments, -ne '' so an empty one adds none
+          $features = ($env:CARGO_FEATURES -split '\s+') -ne ''
+          cargo build @features --all-targets --locked --workspace
 
       - name: Run nextest
         shell: pwsh
@@ -311,7 +310,9 @@ jobs:
           RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
           LLVM_PROFILE_FILE: "profiling/profile-%p-%m.profraw"
         run: |
-          cargo nextest run --profile ci --no-fail-fast --all-targets ${{ env.CARGO_FEATURES }} --workspace
+          # -split so a multi-flag CARGO_FEATURES arrives as separate arguments, -ne '' so an empty one adds none
+          $features = ($env:CARGO_FEATURES -split '\s+') -ne ''
+          cargo nextest run --profile ci --no-fail-fast @features --all-targets --workspace
         continue-on-error: true
 
       - name: Upload test results
@@ -325,11 +326,15 @@ jobs:
       - name: Run grcov
         shell: pwsh
         run: |
-          grcov $(Get-ChildItem -Recurse -Filter '*.profraw' -Path . | % { $_.FullName }) `
+          grcov $(Get-ChildItem -Recurse -Filter 'profile-*.profraw' -Path . | % { $_.FullName }) `
             --binary-path ./target/debug/ `
             --branch `
+            --excl-br-line '^\s*((debug_)?assert(_eq|_ne)?!)' `
+            --excl-br-start 'mod tests \{' `
+            --excl-line '(#\[derive\()|(^\s*.await[;,]?$)' `
+            --excl-start 'mod tests \{' `
             --ignore-not-existing `
-            --keep-only "crates/**/src/**" `
+            --keep-only "crates/**" `
             --llvm `
             --output-path ./reports/lcov.info `
             --output-type lcov `
@@ -406,7 +411,7 @@ jobs:
 
   cargo-clippy-and-report-windows:
     name: Cargo clippy (and report) Windows
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs:
       - changes
     if: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,7 @@ jobs:
           rustup update
 
       - name: Install nextest, custom test runner, with native support for junit and grcov
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-nextest, grcov
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: read # dorny/paths-filter reads the PR's changed files
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
@@ -71,7 +71,8 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cargo build ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
+          # shellcheck disable=SC2086 # CARGO_FEATURES can hold more than one flag
+          cargo build ${CARGO_FEATURES} --all-targets --locked --workspace
 
   cargo-fmt:
     name: Cargo fmt
@@ -103,11 +104,11 @@ jobs:
     name: Cargo test (and report)
     runs-on: ubuntu-26.04
     permissions:
-      checks: write
+      checks: write # publish-unit-test-result-action creates a check run
       contents: read
-      id-token: write
-      issues: read
-      pull-requests: write
+      id-token: write # codecov-action authenticates over OIDC
+      issues: read # publish-unit-test-result-action needs this in private repos
+      pull-requests: write # publish-unit-test-result-action comments the test summary
     steps:
       - *checkout
 
@@ -137,7 +138,8 @@ jobs:
           # build-* ones are not parsed by grcov
           LLVM_PROFILE_FILE: "profiling/build-%p-%m.profraw"
         run: |
-          cargo build ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
+          # shellcheck disable=SC2086 # CARGO_FEATURES can hold more than one flag
+          cargo build ${CARGO_FEATURES} --all-targets --locked --workspace
 
       - name: Run nextest
         shell: bash
@@ -146,7 +148,8 @@ jobs:
           RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
           LLVM_PROFILE_FILE: "profiling/profile-%p-%m.profraw"
         run: |
-          cargo nextest run --profile ci --no-fail-fast ${{ env.CARGO_FEATURES }} --all-targets --workspace
+          # shellcheck disable=SC2086 # CARGO_FEATURES can hold more than one flag
+          cargo nextest run --profile ci --no-fail-fast ${CARGO_FEATURES} --all-targets --workspace
         continue-on-error: true
 
       - name: Upload test results

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,7 @@ jobs:
         name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Check if we actually made changes

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Make sure dictionary words are sorted and unique

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
           show-progress: false
 
       - name: Install zizmor
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: zizmor
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-26.04
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: Install zizmor
+        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: zizmor
+
+      - name: Run zizmor
+        shell: bash
+        env:
+          # a token switches zizmor out of offline mode, enabling the audits that
+          # query GitHub (known-vulnerable actions, ref resolution)
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          zizmor .github

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref_name }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -33,4 +37,4 @@ jobs:
           # query GitHub (known-vulnerable actions, ref resolution)
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          zizmor .github
+          zizmor --persona=pedantic .github

--- a/build-all.sh
+++ b/build-all.sh
@@ -11,10 +11,10 @@ build() {
     docker buildx \
         build \
         --file Dockerfile . \
-        --tag $application_name:latest \
-        --build-arg APPLICATION_NAME=$application_name \
-        --platform $platform \
+        --tag "${application_name}:latest" \
+        --build-arg "APPLICATION_NAME=${application_name}" \
+        --platform "${platform}" \
         --progress=plain
 }
 
-build $(basename ${PWD}) linux/amd64/v3,linux/amd64/v2,linux/amd64,linux/arm64
+build "$(basename "${PWD}")" linux/amd64/v3,linux/amd64/v2,linux/amd64,linux/arm64

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -41,4 +41,4 @@ declare -x "${cxx_var}=${cpp_compiler}"
 cargo_target_linker_var=CARGO_TARGET_${target_upper}_LINKER
 declare -x "${cargo_target_linker_var}=rust-lld"
 
-RUSTFLAGS="$rustflags" cargo auditable "$@" --target ${TARGET}
+RUSTFLAGS="$rustflags" cargo auditable "$@" --target "${TARGET}"

--- a/build-scripts/setup-env.sh
+++ b/build-scripts/setup-env.sh
@@ -3,11 +3,11 @@
 dpkg_add_arch() {
     # are we cross compiling?
     if ! dpkg-architecture --equal "$1"; then
-        dpkg --add-architecture $1
+        dpkg --add-architecture "$1"
     fi
     apt-get update
     apt-get --no-install-recommends install --yes \
-        musl-tools:$1
+        "musl-tools:$1"
 }
 
 case $TARGET in

--- a/generate-test-report.sh
+++ b/generate-test-report.sh
@@ -10,13 +10,15 @@ export LLVM_PROFILE_FILE="profiling/build-%p-%m.profraw"
 cargo build ${cargo_features} --all-targets --locked --workspace
 
 # cleanup old values
-find -name '*.profraw' | xargs rm
+find . -name '*.profraw' -delete
 
 # different from the `cargo build` ones
 LLVM_PROFILE_FILE="profiling/profile-%p-%m.profraw"
 cargo nextest run --profile ci --no-fail-fast ${cargo_features} --all-targets --workspace
 
-grcov $(find . -name "profile-*.profraw" -print) \
+mapfile -d '' profraw_files < <(find . -name "profile-*.profraw" -print0)
+
+grcov "${profraw_files[@]}" \
     --binary-path ./target/debug/ \
     --branch \
     --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!)" \

--- a/project-words.txt
+++ b/project-words.txt
@@ -42,7 +42,6 @@ namedtuple
 nargs
 nextest
 nvmrc
-oneline
 pathbuf
 postprocessors
 prereleased

--- a/project-words.txt
+++ b/project-words.txt
@@ -44,6 +44,7 @@ topo
 trixie
 TRUNC
 uninlined
+uninspectable
 unseparated
 usernamehw
 vadimcn

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,7 @@
 adduser
 appgroup
 appuser
+artipacked
 bkeepers
 buildcache
 cinstrument
@@ -48,3 +49,4 @@ uninspectable
 unseparated
 usernamehw
 vadimcn
+zizmor

--- a/project-words.txt
+++ b/project-words.txt
@@ -5,6 +5,7 @@ artipacked
 bkeepers
 buildcache
 cinstrument
+cliffignore
 ctarget
 cttc
 cves
@@ -24,6 +25,7 @@ multiplatform
 mypy
 nextest
 nvmrc
+oneline
 pathbuf
 postprocessors
 prereleased

--- a/update-name.sh
+++ b/update-name.sh
@@ -2,7 +2,7 @@
 
 new_name=$1
 
-filtered_name=$(echo "${new_name}" | sed -e "s/[a-z0-9-]//g")
+filtered_name="${new_name//[a-z0-9-]/}"
 
 echo "New name = ${new_name}"
 
@@ -11,16 +11,16 @@ if [[ ${#filtered_name} != 0 ]]; then
     exit 1
 fi
 
-new_name_with_underscore=$(echo "${new_name}" | sed -e "s/-/_/g")
+new_name_with_underscore="${new_name//-/_}"
 
 echo "New name with underscore = ${new_name_with_underscore}"
 
 part_name="rust-"
 old_name="${part_name}seed"
-old_name_with_underscore=$(echo "${old_name}" | sed -e "s/-/_/g")
+old_name_with_underscore="${old_name//-/_}"
 
-echo ${old_name_with_underscore}
+echo "${old_name_with_underscore}"
 
-rg --hidden --glob '!.git/*' --files-with-matches ${old_name} | xargs -i sed -i "s/${old_name}/${new_name}/g" {}
-rg --hidden --glob '!.git/*' --files-with-matches ${old_name_with_underscore}
-rg --hidden --glob '!.git/*' --files-with-matches ${old_name_with_underscore} | xargs -i sed -i "s/${old_name_with_underscore}/${new_name_with_underscore}/g" {}
+rg --hidden --glob '!.git/*' --files-with-matches "${old_name}" | xargs --replace={} sed --in-place "s/${old_name}/${new_name}/g" {}
+rg --hidden --glob '!.git/*' --files-with-matches "${old_name_with_underscore}"
+rg --hidden --glob '!.git/*' --files-with-matches "${old_name_with_underscore}" | xargs --replace={} sed --in-place "s/${old_name_with_underscore}/${new_name_with_underscore}/g" {}


### PR DESCRIPTION
- **fix(ci): authenticate container cleanup against ghcr.io and stop treating failed manifest inspection as an image without children**
- **fix(ci): scope write permissions to the jobs that use them and stop interpolating refs into `run` blocks**
- **fix(ci): strip only the leading `v` from the release tag**
- **fix(ci): stop persisting checkout credentials where no step talks to a remote**
- **fix(ci): stop passing every repo secret to `rust.yml`**
- **fix(ci): pass `matrix.platform` through the environment**
- **fix(ci): pass template expansions into `run` blocks through the environment**
- **fix(ci): strip only the leading `v` from the calculated version**
